### PR TITLE
Hotfix/appinspect

### DIFF
--- a/neo4s/README.txt
+++ b/neo4s/README.txt
@@ -1,0 +1,28 @@
+================================================
+Overview
+================================================
+
+This app allows you to run cypher queries and get the results, all over splunk. This allows you to take advantage of both neo4j's cypher and splunk's SPL.
+
+
+================================================
+Configuring Splunk
+================================================
+Install this app into Splunk by doing the following:
+
+  1. Log in to Splunk Web and navigate to "Apps » Manage Apps" via the app dropdown at the top left of Splunk's user interface
+  2. Click the "install app from file" button
+  3. Upload the file by clicking "Choose file" and selecting the app
+  4. Click upload
+  5. Restart Splunk if a dialog asks you to
+
+Once the app is installed, you can use can open the "neo4s" app from the main launcher.
+
+
+================================================
+Getting Support
+================================================
+
+You can access the source-code and get technical details about the app at:
+
+     https://github.com/omerl13/neo4s

--- a/neo4s/default/app.conf
+++ b/neo4s/default/app.conf
@@ -3,7 +3,6 @@
 #
 
 [install]
-is_configured = true
 state = enabled
 allows_disable = true
 


### PR DESCRIPTION
Fixing Splunk AppInspect errors: 
- check_that_setup_has_not_been_performed
  - Removed `is_configured=true` in `default/app.config`
- check_basic_readme
  - Added `README.txt`